### PR TITLE
add libdir for dav1d

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -77,6 +77,7 @@ parts:
     source-tag: '1.2.0'
     meson-parameters:
       - --prefix=/usr
+      - --libdir=/usr/lib/${CRAFT_ARCH_TRIPLET}
       - --buildtype=release
       - --strip
       - -Denable_tools=false


### PR DESCRIPTION
I'm getting `ERROR: dav1d >= 0.5.0 not found using pkg-config` for ffmpeg part without this patch.
meson version is 0.61.2