### PR TITLE
ci: don't rebuild until snap and repos have same mesa libraries

### DIFF
--- a/.github/workflows/update-sdk-snap.yml
+++ b/.github/workflows/update-sdk-snap.yml
@@ -25,18 +25,22 @@ jobs:
           branch: '2404'
           snapcraft-project-root: 'ffmpeg-2404-sdk'
           update-script: |
-            NV_CODEC_HEADERS_VERSION=$(git ls-remote --refs --sort='v:refname' --tags https://git.videolan.org/git/ffmpeg/nv-codec-headers.git     | tail --lines=1 | cut --delimiter='/' --fields=3)
-            yq -i ".parts.nv-codec-headers.source-tag = \"$NV_CODEC_HEADERS_VERSION\"" ffmpeg-2404-sdk/snapcraft.yaml
-            SRT_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --refs --sort='v:refname' --tags https://github.com/Haivision/srt.git | tail --lines=1 | cut --delimiter='/' --fields=3)
-            yq -i ".parts.srt.source-tag = \"$SRT_VERSION\"" ffmpeg-2404-sdk/snapcraft.yaml
-            AVISYNTH_PLUS_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --refs --sort='v:refname' --tags https://github.com/AviSynth/AviSynthPlus.git | tail --lines=1 | cut --delimiter='/' --fields=3)
-            yq -i ".parts.avisynth-plus.source-tag = \"$AVISYNTH_PLUS_VERSION\"" ffmpeg-2404-sdk/snapcraft.yaml
-            DAV1D_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --refs --sort='v:refname' --tags https://code.videolan.org/videolan/dav1d.git | tail --lines=1 | cut --delimiter='/' --fields=3)
-            yq -i ".parts.dav1d.source-tag = \"$DAV1D_VERSION\"" ffmpeg-2404-sdk/snapcraft.yaml
-            ZIMG_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --refs --sort='v:refname' --tags https://github.com/sekrit-twc/zimg.git | tail --lines=1 | cut --delimiter='/' --fields=3)
-            yq -i ".parts.zimg.source-tag = \"$ZIMG_VERSION\"" ffmpeg-2404-sdk/snapcraft.yaml
-            FFMPEG_VERSION=$(git ls-remote --refs --sort='v:refname' --tags https://git.videolan.org/git/ffmpeg.git | awk '{print $2}' | sed 's/refs\/tags\///' | grep -v '^v' | grep -v '^ffmpeg' | grep -v '\-dev' | tail --lines=1 | cut -c 2-)
-            yq -i ".version=\"$FFMPEG_VERSION\"" ffmpeg-2404-sdk/snapcraft.yaml
+            if [ "$mesa_apt_version" == "$mesa_snap_version" ]; then
+              NV_CODEC_HEADERS_VERSION=$(git ls-remote --refs --sort='v:refname' --tags https://git.videolan.org/git/ffmpeg/nv-codec-headers.git     | tail --lines=1 | cut --delimiter='/' --fields=3)
+              yq -i ".parts.nv-codec-headers.source-tag = \"$NV_CODEC_HEADERS_VERSION\"" ffmpeg-2404-sdk/snapcraft.yaml
+              SRT_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --refs --sort='v:refname' --tags https://github.com/Haivision/srt.git | tail --lines=1 | cut --delimiter='/' --fields=3)
+              yq -i ".parts.srt.source-tag = \"$SRT_VERSION\"" ffmpeg-2404-sdk/snapcraft.yaml
+              AVISYNTH_PLUS_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --refs --sort='v:refname' --tags https://github.com/AviSynth/AviSynthPlus.git | tail --lines=1 | cut --delimiter='/' --fields=3)
+              yq -i ".parts.avisynth-plus.source-tag = \"$AVISYNTH_PLUS_VERSION\"" ffmpeg-2404-sdk/snapcraft.yaml
+              DAV1D_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --refs --sort='v:refname' --tags https://code.videolan.org/videolan/dav1d.git | tail --lines=1 | cut --delimiter='/' --fields=3)
+              yq -i ".parts.dav1d.source-tag = \"$DAV1D_VERSION\"" ffmpeg-2404-sdk/snapcraft.yaml
+              ZIMG_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --refs --sort='v:refname' --tags https://github.com/sekrit-twc/zimg.git | tail --lines=1 | cut --delimiter='/' --fields=3)
+              yq -i ".parts.zimg.source-tag = \"$ZIMG_VERSION\"" ffmpeg-2404-sdk/snapcraft.yaml
+              FFMPEG_VERSION=$(git ls-remote --refs --sort='v:refname' --tags https://git.videolan.org/git/ffmpeg.git | awk '{print $2}' | sed 's/refs\/tags\///' | grep -v '^v' | grep -v '^ffmpeg' | grep -v '\-dev' | tail --lines=1 | cut -c 2-)
+              yq -i ".version=\"$FFMPEG_VERSION\"" ffmpeg-2404-sdk/snapcraft.yaml
+            else
+              echo "Mesa in Ubuntu Repos and Snap are not same. Skipping checks."
+            fi
 
   sync-content-version:
     needs: sync-sdk


### PR DESCRIPTION
This PR ensures, we're never in a state, where we have different mesa libraries while build time and runtime. This will remove any instances of runtime errors and mismatches of the mesa library versions. Though, just like every other issues, we might be in a scenario where, the moment the check passed, and the build started, the Ubuntu repo got updated and new mesa is there. I am not sure, how can stop that. But, I guess we can atleast have some tests, and see if it passes the test. After which we'll push this to stable.