### PR TITLE
sdk: use libva from the repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Now in the apps part which needs to use the ffmpeg libraries during runtime, you
 apps:
   app:
     environment:
-        LD_LIBRARY_PATH: $SNAP/ffmpeg-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$LD_LIBRARY_PATH
-        PATH: $SNAP/ffmpeg-platform/usr/bin:$PATH
+      LD_LIBRARY_PATH: $SNAP/ffmpeg-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$LD_LIBRARY_PATH
+      PATH: $SNAP/ffmpeg-platform/usr/bin:$PATH
 ```
 You can also declare these variables at the top level of your `snapcraft.yaml` if you want to use them in all the apps. Some snaps that use this ffmpeg-sdk.
 

--- a/ffmpeg-2404-sdk/snapcraft.yaml
+++ b/ffmpeg-2404-sdk/snapcraft.yaml
@@ -134,23 +134,6 @@ parts:
       - libxcb1-dev
       - libxrandr-dev
       - pkg-config
-  libva:
-    source: https://github.com/intel/libva.git
-    source-tag: '2.21.0'
-    source-depth: 1
-    plugin: meson
-    meson-parameters:
-      - --prefix=/usr
-      - -Doptimization=3
-      - -Ddebug=true
-      - -Dwith_x11=yes
-      - -Dwith_glx=yes
-      - -Dwith_wayland=yes
-    build-packages:
-      - meson
-      - libxcb-dri3-dev
-      - libx11-xcb-dev
-    override-prime: ''
   ffmpeg:
     after:
       - avisynth-plus
@@ -159,7 +142,6 @@ parts:
       - srt
       - x264
       - zimg
-      - libva
       - vulkan-loaders
     plugin: autotools
     source: https://git.ffmpeg.org/ffmpeg.git


### PR DESCRIPTION
libva was needed to build from source because the gnome sdk did the same. and using a different API while building would've brought API incompatibilities. Not needed anymore as Gnome SDK silently removed it.