### PR TITLE
many: add riscv support and drop OMX/Sndio, improve build

### DIFF
--- a/.github/workflows/update-sdk-snap.yml
+++ b/.github/workflows/update-sdk-snap.yml
@@ -35,6 +35,12 @@ jobs:
             yq -i ".parts.dav1d.source-tag = \"$DAV1D_VERSION\"" ffmpeg-2404-sdk/snapcraft.yaml
             ZIMG_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --refs --sort='v:refname' --tags https://github.com/sekrit-twc/zimg.git | tail --lines=1 | cut --delimiter='/' --fields=3)
             yq -i ".parts.zimg.source-tag = \"$ZIMG_VERSION\"" ffmpeg-2404-sdk/snapcraft.yaml
+            LIBDOVI_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --refs --sort='v:refname' --tags https://github.com/quietvoid/dovi_tool.git | tail --lines=1 | cut --delimiter='/' --fields=3)
+            yq -i ".parts.libdovi.source-tag = \"$LIBDOVI_VERSION\"" ffmpeg-2404-sdk/snapcraft.yaml
+            PLACEBO_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --refs --sort='v:refname' --tags https://code.videolan.org/videolan/libplacebo.git | tail --lines=1 | cut --delimiter='/' --fields=3)
+            yq -i ".parts.placebo.source-tag = \"$PLACEBO_VERSION\"" ffmpeg-2404-sdk/snapcraft.yaml
+            SVT_AV1_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --refs --sort='v:refname' --tags https://gitlab.com/AOMediaCodec/SVT-AV1.git | tail --lines=1 | cut --delimiter='/' --fields=3)
+            yq -i ".parts.svt-av1.source-tag = \"$SVT_AV1_VERSION\"" ffmpeg-2404-sdk/snapcraft.yaml
             FFMPEG_VERSION=$(git ls-remote --refs --sort='v:refname' --tags https://git.videolan.org/git/ffmpeg.git | awk '{print $2}' | sed 's/refs\/tags\///' | grep -v '^v' | grep -v '^ffmpeg' | grep -v '\-dev' | tail --lines=1 | cut -c 2-)
             yq -i ".version=\"$FFMPEG_VERSION\"" ffmpeg-2404-sdk/snapcraft.yaml
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ Now in the apps part which needs to use the ffmpeg libraries during runtime, you
 apps:
   app:
     environment:
-      LD_LIBRARY_PATH: $SNAP/ffmpeg-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$LD_LIBRARY_PATH
-      PATH: $SNAP/ffmpeg-platform/usr/bin:$PATH
+      LD_LIBRARY_PATH: $SNAP/ffmpeg-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
+      PATH: $SNAP/ffmpeg-platform/usr/bin
 ```
 You can also declare these variables at the top level of your `snapcraft.yaml` if you want to use them in all the apps. Some snaps that use this ffmpeg-sdk.
 

--- a/ffmpeg-2404-sdk/patches/0002-avcodec-libsvtav1-unbreak-build-with-latest-svtav1.patch
+++ b/ffmpeg-2404-sdk/patches/0002-avcodec-libsvtav1-unbreak-build-with-latest-svtav1.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gyan Doshi <ffmpeg@gyani.pro>
+Date: Sat, 22 Feb 2025 10:38:53 +0530
+Subject: [PATCH] avcodec/libsvtav1: unbreak build with latest svtav1
+
+SVT-AV1 made a change in their public API in 988e930c but without a
+version bump or any other accessible marker, thus breaking ffmpeg build
+with current versions of SVT-AV1.
+
+They have finally bumped versions a month later, so check added.
+---
+ libavcodec/libsvtav1.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/libavcodec/libsvtav1.c b/libavcodec/libsvtav1.c
+index 79b28eb4df54..43fe531fde74 100644
+--- a/libavcodec/libsvtav1.c
++++ b/libavcodec/libsvtav1.c
+@@ -435,7 +435,11 @@ static av_cold int eb_enc_init(AVCodecContext *avctx)
+ 
+     svt_enc->eos_flag = EOS_NOT_REACHED;
+ 
++#if SVT_AV1_CHECK_VERSION(3, 0, 0)
++    svt_ret = svt_av1_enc_init_handle(&svt_enc->svt_handle, &svt_enc->enc_params);
++#else
+     svt_ret = svt_av1_enc_init_handle(&svt_enc->svt_handle, svt_enc, &svt_enc->enc_params);
++#endif
+     if (svt_ret != EB_ErrorNone) {
+         return svt_print_error(avctx, svt_ret, "Error initializing encoder handle");
+     }

--- a/ffmpeg-2404-sdk/snapcraft.yaml
+++ b/ffmpeg-2404-sdk/snapcraft.yaml
@@ -26,6 +26,7 @@ platforms:
   arm64:
   armhf:
   ppc64el:
+  riscv64:
 parts:
   nv-codec-headers:
     plugin: make
@@ -165,7 +166,6 @@ parts:
       - libgsm1-dev
       - liblzma-dev
       - libmp3lame-dev
-      - libomxil-bellagio-dev
       - libopenal-dev
       - libopencore-amrnb-dev
       - libopencore-amrwb-dev
@@ -217,13 +217,13 @@ parts:
     override-build: |
       if [ "$CRAFT_ARCH_BUILD_FOR" = "amd64" ]; then
         # TODO: re-enable `--enable-cuda-sdk --enable-cuda --enable-libnpp` if we can determine that we can ship non-free
-        EXTRA="--enable-vdpau --enable-nvenc --enable-cuvid"
-      elif [ "$CRAFT_ARCH_BUILD_FOR" = "i386" ]; then
-        EXTRA="--enable-vdpau --enable-nvenc"
+        EXTRA="--enable-libglslang --enable-vdpau --enable-nvenc --enable-cuvid --enable-nvdec"
       elif [ "$CRAFT_ARCH_BUILD_FOR" = "armhf" ]; then
-        EXTRA="--disable-vdpau --enable-neon"
+        EXTRA="--disable-vdpau --enable-neon --disable-libmfx"
       elif [ "$CRAFT_ARCH_BUILD_FOR" = "arm64" ]; then
-        EXTRA="--disable-vdpau"
+        EXTRA="--disable-vdpau --disable-libmfx"
+      elif [ "$CRAFT_ARCH_BUILD_FOR" = "riscv64" ]; then
+        EXTRA="--disable-asm" # https://trac.ffmpeg.org/ticket/11258
       else
         EXTRA=""
       fi
@@ -238,7 +238,9 @@ parts:
       --disable-txtpages \
       --disable-static \
       --enable-libaom \
+      --disable-sndio \
       --enable-avisynth \
+      --enable-chromaprint \
       --enable-libdav1d \
       --enable-ffplay \
       --enable-gnutls \
@@ -257,7 +259,11 @@ parts:
       --enable-libfreetype \
       --enable-libgme \
       --enable-libgsm \
+      --enable-libharfbuzz \
+      --enable-libiec61883 \
       --enable-libmp3lame \
+      --enable-libmysofa \
+      --enable-libplacebo \
       --enable-libopencore_amrnb \
       --enable-libopencore_amrwb \
       --enable-libopenjpeg \
@@ -272,10 +278,12 @@ parts:
       --enable-libspeex \
       --enable-libsrt \
       --enable-libssh \
+      --enable-libsvtav1 \
       --enable-libtesseract \
       --enable-libtheora \
       --enable-libtwolame \
       --enable-libv4l2 \
+      --enable-libvidstab \
       --enable-libvo_amrwbenc \
       --enable-libvorbis \
       --enable-libvpx \
@@ -288,7 +296,7 @@ parts:
       --enable-libzimg \
       --enable-libzmq \
       --enable-libzvbi \
-      --enable-omx \
+      --disable-omx \
       --enable-openal \
       --enable-opencl \
       --enable-opengl \
@@ -301,8 +309,6 @@ parts:
       --enable-xlib ${EXTRA}
 
       # TODO: re-enable `--enable-nonfree \` if we can determine the legality/licensing issues are ok.
-
-      # TODO: re-enable vulkan
 
       make -j $(nproc)
       make DESTDIR="$CRAFT_PART_INSTALL" install

--- a/ffmpeg-2404-sdk/snapcraft.yaml
+++ b/ffmpeg-2404-sdk/snapcraft.yaml
@@ -157,6 +157,7 @@ parts:
       - libbz2-dev
       - libcaca-dev
       - libcdio-paranoia-dev
+      - libchromaprint-dev
       - libcodec2-dev
       - libdc1394-dev
       - libdrm-dev
@@ -164,6 +165,7 @@ parts:
       - libgme-dev
       - libgnutls28-dev
       - libgsm1-dev
+      - libiec61883-dev
       - liblzma-dev
       - libmp3lame-dev
       - libopenal-dev
@@ -240,7 +242,6 @@ parts:
       --enable-libaom \
       --disable-sndio \
       --enable-avisynth \
-      --enable-chromaprint \
       --enable-libdav1d \
       --enable-ffplay \
       --enable-gnutls \

--- a/ffmpeg-2404-sdk/snapcraft.yaml
+++ b/ffmpeg-2404-sdk/snapcraft.yaml
@@ -135,22 +135,74 @@ parts:
       - libxcb1-dev
       - libxrandr-dev
       - pkg-config
+  rustup:
+    plugin: rust
+    source: .
+    rust-channel: "1.88"
+    override-build: ""
+    override-prime: ""
+  libdovi:
+    after: [rustup]
+    source: https://github.com/quietvoid/dovi_tool.git
+    source-tag: "libdovi-3.3.2"
+    source-subdir: "dolby_vision"
+    plugin: nil
+    build-environment:
+      - PATH: ${HOME}/.cargo/bin:${PATH}
+    override-build: |
+      craftctl default
+      cargo install cargo-c
+      cd dolby_vision
+      cargo cinstall --release --prefix $CRAFT_PART_INSTALL/usr
+  placebo:
+    after:
+      - libdovi
+    source: https://code.videolan.org/videolan/libplacebo.git
+    source-tag: 'v7.351.0'
+    source-depth: 1
+    plugin: meson
+    build-packages:
+      - liblcms2-dev
+    meson-parameters:
+      - --prefix=/usr
+      - --buildtype=release
+      - -Dtests=false
+      - -Ddemos=false
+      - -Dd3d11=disabled
+      - -Ddovi=enabled
+      - -Dlibdovi=enabled
+      - -Dlcms=enabled      
+      - -Dglslang=enabled
+      - -Dshaderc=enabled
+  svt-av1:
+    source: https://gitlab.com/AOMediaCodec/SVT-AV1.git
+    source-depth: 1
+    source-tag: 'v3.0.2'
+    plugin: cmake
+    cmake-parameters:
+      - -DCMAKE_INSTALL_PREFIX=/usr
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DBUILD_SHARED_LIBS=ON
+      - -DNATIVE=OFF
   ffmpeg:
     after:
       - avisynth-plus
       - dav1d
       - nv-codec-headers
+      - placebo
       - srt
+      - svt-av1
       - x264
       - zimg
       - vulkan-loaders
-    plugin: autotools
+    plugin: nil
     source: https://git.ffmpeg.org/ffmpeg.git
     source-tag: 'n$SNAPCRAFT_PROJECT_VERSION'
     source-depth: 1
     build-packages:
-      - libaom-dev
       - flite1-dev
+      - glslang-tools
+      - libaom-dev
       - libass-dev
       - libbs2b-dev
       - libbluray-dev
@@ -165,9 +217,9 @@ parts:
       - libgme-dev
       - libgnutls28-dev
       - libgsm1-dev
-      - libiec61883-dev
       - liblzma-dev
       - libmp3lame-dev
+      - libmysofa-dev
       - libopenal-dev
       - libopencore-amrnb-dev
       - libopencore-amrwb-dev
@@ -179,6 +231,7 @@ parts:
       - librubberband-dev
       - libsctp-dev
       - libsdl2-dev
+      - libshaderc-dev
       - libshine-dev
       - libsnappy-dev
       - libsoxr-dev
@@ -190,6 +243,7 @@ parts:
       - libva-dev
       - libv4l-dev
       - libvdpau-dev
+      - libvidstab-dev
       - libvo-amrwbenc-dev
       - libvorbis-dev
       - libvpx-dev
@@ -208,6 +262,7 @@ parts:
       - ocl-icd-opencl-dev
       - opencl-headers
       - pkg-config
+      - spirv-tools
       - yasm
       #- on amd64:
       #- libcrystalhd-dev
@@ -216,7 +271,11 @@ parts:
       # - nvidia-cuda-toolkit
       #- on i386:
       #- libcrystalhd-dev
+    build-environment:
+      - LD_LIBRARY_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
     override-build: |
+      patch -p1 < ${CRAFT_PROJECT_DIR}/patches/0002-avcodec-libsvtav1-unbreak-build-with-latest-svtav1.patch
+      craftctl default
       if [ "$CRAFT_ARCH_BUILD_FOR" = "amd64" ]; then
         # TODO: re-enable `--enable-cuda-sdk --enable-cuda --enable-libnpp` if we can determine that we can ship non-free
         EXTRA="--enable-libglslang --enable-vdpau --enable-nvenc --enable-cuvid --enable-nvdec"
@@ -261,7 +320,6 @@ parts:
       --enable-libgme \
       --enable-libgsm \
       --enable-libharfbuzz \
-      --enable-libiec61883 \
       --enable-libmp3lame \
       --enable-libmysofa \
       --enable-libplacebo \
@@ -347,6 +405,7 @@ parts:
       - libgme0
       - libgsm1
       - libmp3lame0
+      - libmysofa1
       - libopenal1
       - libopencore-amrnb0
       - libopencore-amrwb0
@@ -363,6 +422,7 @@ parts:
       - libusb-1.0-0
       - libv4l-0t64
       - libv4l2rds0t64
+      - libvidstab1.1
       - libvdpau-va-gl1
       - libvo-amrwbenc0
       - libvpx9

--- a/ffmpeg-2404/snapcraft.yaml
+++ b/ffmpeg-2404/snapcraft.yaml
@@ -27,6 +27,7 @@ platforms:
   arm64:
   armhf:
   ppc64el:
+  riscv64:
 slots:
   ffmpeg-2404:
     interface: content


### PR DESCRIPTION
1. added riscv64 to supported platforms
2. build libplacebo with dolby-audio, glslang, lcms and shaderc support
3. build svt-av1 from source as a shared library
4. disabled sndio and omx (not relevant for linux)
5. dropped libomxil-bellagio-dev
6. improved build flags for better hardware accel and compatibility
7. enabled nvdec, libglslang, libplacebo, chromaprint, etc for better hdr and hw acceleration support
8. disabled libmfx on ARM and asm optimization on RISC-V ([upstream issue](https://trac.ffmpeg.org/ticket/11258))
9. fixed up environment overrides in README
10. add the new parts placebo, svt-av1 and libdovi for auto update in CI