### PR TITLE
snap: revert to ffmpeg 7.1.1

### DIFF
--- a/ffmpeg-2404-sdk/snapcraft.yaml
+++ b/ffmpeg-2404-sdk/snapcraft.yaml
@@ -138,7 +138,6 @@ parts:
   rustup:
     plugin: rust
     source: .
-    rust-channel: "1.88"
     override-build: ""
     override-prime: ""
   libdovi:

--- a/ffmpeg-2404-sdk/snapcraft.yaml
+++ b/ffmpeg-2404-sdk/snapcraft.yaml
@@ -2,7 +2,7 @@ name: ffmpeg-2404-sdk
 title: FFmpeg SDK for Snaps
 summary: SDK for ffmpeg-2404
 description: SDK to build ffmpeg-2404 content snap
-version: '8.0.1'
+version: '7.1.1'
 base: core24
 grade: stable
 confinement: strict

--- a/ffmpeg-2404/snapcraft.yaml
+++ b/ffmpeg-2404/snapcraft.yaml
@@ -4,7 +4,7 @@ summary: ffmpeg content snap for core24
 description: |
   FFmpeg is a collection of libraries and tools to process multimedia content such as audio, video, subtitles and related metadata.
   This snap is meant to be consumed with the gnome extension.
-version: '8.0.1'
+version: '7.1.1'
 base: core24
 grade: stable
 confinement: strict


### PR DESCRIPTION
we need to rebuild the sdks, so this reversal is required