### PR TITLE
Enable s390x architecture

### DIFF
--- a/ffmpeg-2404-sdk/patches/avisynthplus/0001-Initial-support-for-z-Architecture.patch
+++ b/ffmpeg-2404-sdk/patches/avisynthplus/0001-Initial-support-for-z-Architecture.patch
@@ -1,0 +1,16 @@
+Initial support for z/Architecture · AviSynth/AviSynthPlus@ae884c1
+https://github.com/AviSynth/AviSynthPlus/commit/ae884c1
+--- a/avs_core/include/avs/config.h
++++ b/avs_core/include/avs/config.h
+@@ -65,6 +65,8 @@
+ #   define SPARC
+ #elif defined(__mips__)
+ #   define MIPS
++#elif defined(__s390x__)
++#   define S390X
+ #else
+ #   error Unsupported CPU architecture.
+ #endif
+-- 
+2.51.0
+

--- a/ffmpeg-2404-sdk/patches/avisynthplus/0002-TargetArch.cmake-basic-z-Architecture-naming.patch
+++ b/ffmpeg-2404-sdk/patches/avisynthplus/0002-TargetArch.cmake-basic-z-Architecture-naming.patch
@@ -1,0 +1,16 @@
+TargetArch.cmake: basic z/Architecture naming · AviSynth/AviSynthPlus@d0ba141
+https://github.com/AviSynth/AviSynthPlus/commit/d0ba141
+--- a/avs_core/TargetArch.cmake
++++ b/avs_core/TargetArch.cmake
+@@ -57,6 +57,8 @@ set(archdetect_c_code "
+     #error cmake_ARCH sparc
+ #elif defined(__mips__)
+     #error cmake_ARCH mips
++#elif defined(__s390x__)
++    #error cmake_ARCH s390x
+ #endif
+ 
+ #error cmake_ARCH unknown
+-- 
+2.51.0
+

--- a/ffmpeg-2404-sdk/snapcraft.yaml
+++ b/ffmpeg-2404-sdk/snapcraft.yaml
@@ -27,6 +27,7 @@ platforms:
   armhf:
   ppc64el:
   riscv64:
+  s390x:
 parts:
   nv-codec-headers:
     plugin: make
@@ -62,6 +63,10 @@ parts:
       - -DCMAKE_BUILD_TYPE=Release
       - -DCMAKE_C_FLAGS_RELEASE=-s
       - -DCMAKE_CXX_FLAGS_RELEASE=-s
+    override-pull: |
+      craftctl default
+      patch -p1 < ${CRAFT_PROJECT_DIR}/patches/avisynthplus/0001-Initial-support-for-z-Architecture.patch
+      patch -p1 < ${CRAFT_PROJECT_DIR}/patches/avisynthplus/0002-TargetArch.cmake-basic-z-Architecture-naming.patch
   x264:
     plugin: autotools
     source: https://code.videolan.org/videolan/x264.git

--- a/ffmpeg-2404/snapcraft.yaml
+++ b/ffmpeg-2404/snapcraft.yaml
@@ -28,6 +28,8 @@ platforms:
   armhf:
   ppc64el:
   riscv64:
+  s390x:
+
 slots:
   ffmpeg-2404:
     interface: content


### PR DESCRIPTION
This pull request fixes s390x compatibility by including 2 trivial Avisynth+ patches that enables the architecture support.

Fixes #84.