### PR TITLE
fix: serialize remote-build release jobs

### DIFF
--- a/.github/workflows/release-content-to-candidate.yml
+++ b/.github/workflows/release-content-to-candidate.yml
@@ -39,6 +39,10 @@ jobs:
     environment: "2404 Branch"
     strategy:
       fail-fast: false
+      # snapcraft remote-build uses a shared Launchpad git repo name per project.
+      # Running every architecture in parallel can race on that branch and make
+      # sibling jobs fail before the build starts.
+      max-parallel: 1
       matrix:
         architecture: ${{ fromJSON(needs.get-architectures.outputs.architectures-list) }}
     steps:

--- a/.github/workflows/release-sdk-to-candidate.yml
+++ b/.github/workflows/release-sdk-to-candidate.yml
@@ -38,6 +38,10 @@ jobs:
     timeout-minutes: 720
     strategy:
       fail-fast: false
+      # snapcraft remote-build uses a shared Launchpad git repo name per project.
+      # Running every architecture in parallel can race on that branch and make
+      # sibling jobs fail before the build starts.
+      max-parallel: 1
       matrix:
         architecture: ${{ fromJSON(needs.get-architectures.outputs.architectures-list) }}
     steps:


### PR DESCRIPTION
This release workflow uses `snapcraft remote-build` once per architecture from a matrix. The failed run showed the jobs racing against the same Launchpad remote-build git repository name, e.g. one job created `...snapcraft-ffmpeg-2404-sdk-54e2cfd4...` while another immediately failed with:

- `remote: error: cannot lock ref 'refs/heads/main': reference already exists`
- `Git operation failed with: Could not push 'HEAD' ... refs/heads/master:refs/heads/main`
- then downstream review failures because the expected `.snap` file did not exist

This adds `strategy.max-parallel: 1` to the SDK and content release matrices so each architecture gets exclusive use of the generated Launchpad remote-build repository before the next architecture starts.

Validation:
- Parsed all workflow YAML files with PyYAML
- Ran `git diff --check`

Fixes investigation for https://github.com/snapcrafters/ffmpeg-2404-sdk/actions/runs/27088338745
