### PR TITLE
fix: resolve armhf x264 soname cleanup

### DIFF
--- a/ffmpeg-2404-sdk/snapcraft.yaml
+++ b/ffmpeg-2404-sdk/snapcraft.yaml
@@ -392,7 +392,8 @@ parts:
         sed -i 's#includedir=/usr#includedir=${prefix}#' $PC
       done
       if [ "$CRAFT_ARCH_TRIPLET_BUILD_FOR" == "arm-linux-gnueabihf" ]; then
-        execstack --clear-execstack usr/lib/arm-linux-gnueabihf/libx264.so.164
+        x264_lib="$(find usr/lib/arm-linux-gnueabihf -maxdepth 1 -type f -name 'libx264.so.*' | sort -V | tail -n1)"
+        execstack --clear-execstack "$x264_lib"
       fi
   deps:
     after: [ffmpeg, prefix-fix]


### PR DESCRIPTION
Summary:
- Replaces the armhf hard-coded libx264.so.164 execstack cleanup target with discovery of the staged libx264.so.* file.
- Keeps the cleanup in place while allowing x264 soname bumps such as libx264.so.165.

Evidence:
- Failed run: https://github.com/snapcrafters/ffmpeg-2404-sdk/actions/runs/27099970208
- The armhf build installed libx264.so.165, then prefix-fix failed running execstack against libx264.so.164.

Verification:
- Parsed snapcraft.yaml with Python yaml.safe_load.
- Verified the finder selects libx264.so.165 over libx264.so.164 in a synthetic staged directory.
- Ran git diff --check.
- Commit is signed.

@jnsgruk for review once PR CI/release validation has signal.
