### PR TITLE
fix: use stable SRT releases for SDK builds

### DIFF
--- a/.github/workflows/update-sdk-snap.yml
+++ b/.github/workflows/update-sdk-snap.yml
@@ -27,7 +27,7 @@ jobs:
           update-script: |
             NV_CODEC_HEADERS_VERSION=$(git ls-remote --refs --sort='v:refname' --tags https://git.videolan.org/git/ffmpeg/nv-codec-headers.git | tail --lines=1 | cut --delimiter='/' --fields=3)
             yq -i ".parts.nv-codec-headers.source-tag = \"$NV_CODEC_HEADERS_VERSION\"" ffmpeg-2404-sdk/snapcraft.yaml
-            SRT_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --refs --sort='v:refname' --tags https://github.com/Haivision/srt.git | grep -v '\-rc' | tail --lines=1 | cut --delimiter='/' --fields=3)
+            SRT_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --refs --sort='v:refname' --tags https://github.com/Haivision/srt.git 'refs/tags/v[0-9]*' | grep -E 'refs/tags/v[0-9]+(\.[0-9]+)*$' | tail --lines=1 | cut --delimiter='/' --fields=3)
             yq -i ".parts.srt.source-tag = \"$SRT_VERSION\"" ffmpeg-2404-sdk/snapcraft.yaml
             AVISYNTH_PLUS_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --refs --sort='v:refname' --tags https://github.com/AviSynth/AviSynthPlus.git | tail --lines=1 | cut --delimiter='/' --fields=3)
             yq -i ".parts.avisynth-plus.source-tag = \"$AVISYNTH_PLUS_VERSION\"" ffmpeg-2404-sdk/snapcraft.yaml

--- a/ffmpeg-2404-sdk/snapcraft.yaml
+++ b/ffmpeg-2404-sdk/snapcraft.yaml
@@ -42,7 +42,7 @@ parts:
   srt:
     plugin: cmake
     source: https://github.com/Haivision/srt.git
-    source-tag: 'x1.2.0'
+    source-tag: 'v1.5.5'
     source-depth: 1
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr


### PR DESCRIPTION
## Summary
- bump the SDK SRT part from Haivision's historical `x1.2.0` tag to the current stable `v1.5.5` release
- filter the scheduled SDK update workflow to stable `v*` SRT release tags so it does not re-select `x1.2.0`

## Failure evidence
The failed release job hit the SRT 1.2.0 sample app build before the final missing-snap artifact error:

```text
/build/.../parts/srt/src/apps/stransmit.cpp:366:9: error: expected unqualified-id before ‘if’
/build/.../parts/srt/src/apps/stransmit.cpp:370:28: error: ‘data’ was not declared in this scope
/build/.../parts/srt/src/apps/stransmit.cpp:371:17: error: ‘maddr’ does not name a type
Failed to run the build script for part 'srt'.
```

Run: https://github.com/snapcrafters/ffmpeg-2404-sdk/actions/runs/27161497848/job/80312614123

## Verification
- `parts.srt.source-tag == v1.5.5` and `-DENABLE_APPS=OFF` is still present
- filtered SRT lookup selects `v1.5.5` and ignores `x1.2.0`
- `git diff --check`
- `snapcraft expand-extensions` from `ffmpeg-2404-sdk/`
- locally built and installed SRT `v1.5.5` with the recipe CMake parameters; verified `srt.h`, `version.h`, `libsrt.so`, `srt.pc`, `Version: 1.5.5`, and `SRT_TRANSTYPE`

@jnsgruk