### PR TITLE
ci: use GitHub mirrors for FFmpeg version sync

### DIFF
--- a/.github/workflows/update-sdk-snap.yml
+++ b/.github/workflows/update-sdk-snap.yml
@@ -25,7 +25,7 @@ jobs:
           branch: '2404'
           snapcraft-project-root: 'ffmpeg-2404-sdk'
           update-script: |
-            NV_CODEC_HEADERS_VERSION=$(git ls-remote --refs --sort='v:refname' --tags https://git.videolan.org/git/ffmpeg/nv-codec-headers.git | tail --lines=1 | cut --delimiter='/' --fields=3)
+            NV_CODEC_HEADERS_VERSION=$(git ls-remote --refs --sort='v:refname' --tags https://github.com/FFmpeg/nv-codec-headers.git | tail --lines=1 | cut --delimiter='/' --fields=3)
             yq -i ".parts.nv-codec-headers.source-tag = \"$NV_CODEC_HEADERS_VERSION\"" ffmpeg-2404-sdk/snapcraft.yaml
             SRT_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --refs --sort='v:refname' --tags https://github.com/Haivision/srt.git 'refs/tags/v[0-9]*' | grep -E 'refs/tags/v[0-9]+(\.[0-9]+)*$' | tail --lines=1 | cut --delimiter='/' --fields=3)
             yq -i ".parts.srt.source-tag = \"$SRT_VERSION\"" ffmpeg-2404-sdk/snapcraft.yaml
@@ -41,7 +41,7 @@ jobs:
             yq -i ".parts.placebo.source-tag = \"$PLACEBO_VERSION\"" ffmpeg-2404-sdk/snapcraft.yaml
             SVT_AV1_VERSION=$(git -c 'versionsort.suffix=-' ls-remote --refs --sort='v:refname' --tags https://gitlab.com/AOMediaCodec/SVT-AV1.git | tail --lines=1 | cut --delimiter='/' --fields=3)
             yq -i ".parts.svt-av1.source-tag = \"$SVT_AV1_VERSION\"" ffmpeg-2404-sdk/snapcraft.yaml
-            FFMPEG_VERSION=$(git ls-remote --refs --sort='v:refname' --tags https://git.videolan.org/git/ffmpeg.git | awk '{print $2}' | sed 's/refs\/tags\///' | grep -v '^v' | grep -v '^ffmpeg' | grep -v '\-dev' | tail --lines=1 | cut -c 2-)
+            FFMPEG_VERSION=$(git ls-remote --refs --sort='v:refname' --tags https://github.com/FFmpeg/FFmpeg.git | awk '{print $2}' | sed 's/refs\/tags\///' | grep -v '^v' | grep -v '^ffmpeg' | grep -v '\-dev' | tail --lines=1 | cut -c 2-)
             yq -i ".version=\"$FFMPEG_VERSION\"" ffmpeg-2404-sdk/snapcraft.yaml
 
   sync-content-version:
@@ -57,5 +57,5 @@ jobs:
           branch: '2404'
           snapcraft-project-root: "ffmpeg-2404"
           update-script: |
-            FFMPEG_VERSION=$(git ls-remote --refs --sort='v:refname' --tags https://git.videolan.org/git/ffmpeg.git | awk '{print $2}' | sed 's/refs\/tags\///' | grep -v '^v' | grep -v '^ffmpeg' | grep -v '\-dev' | tail --lines=1 | cut -c 2-)
+            FFMPEG_VERSION=$(git ls-remote --refs --sort='v:refname' --tags https://github.com/FFmpeg/FFmpeg.git | awk '{print $2}' | sed 's/refs\/tags\///' | grep -v '^v' | grep -v '^ffmpeg' | grep -v '\-dev' | tail --lines=1 | cut -c 2-)
             yq -i ".version=\"$FFMPEG_VERSION\"" ffmpeg-2404/snapcraft.yaml


### PR DESCRIPTION
## Summary
- Switch the update workflow's FFmpeg and nv-codec-headers lookups from git.videolan.org to the GitHub mirrors.
- Avoid scheduled sync failures when git.videolan.org returns HTTP 500.

## Verification
- Parsed .github/workflows/update-sdk-snap.yml as YAML.
- Ran git diff --check.
- Verified the GitHub mirror selectors return expected values:
  - nv-codec-headers: n13.0.19.0
  - FFmpeg tags: 8.1.1 for the 2404 tag-based updater, or release/8.1 / 8.1 for the 2204 branch-based updater

@jnsgruk
